### PR TITLE
Revise project structure for loading and rendering GLB 3D models

### DIFF
--- a/app/components/Model.tsx
+++ b/app/components/Model.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useLoader } from '@react-three/fiber';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+
+const Model = () => {
+  const gltf = useLoader(GLTFLoader, '/models/scene.glb');
+  return <primitive object={gltf.scene} />;
+};
+
+export default Model;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Canvas } from '@react-three/fiber';
+import Model from './components/Model';
+
+const HomePage = () => {
+  return (
+    <div style={{ width: '100vw', height: '100vh' }}>
+      <Canvas>
+        <Model />
+      </Canvas>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,18 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.(glb|gltf)$/,
+      use: {
+        loader: 'file-loader',
+        options: {
+          outputPath: 'static/models/',
+        },
+      },
+    });
+    return config;
+  },
+};
+
+module.exports = nextConfig;

--- a/styles/canvas.css
+++ b/styles/canvas.css
@@ -1,0 +1,7 @@
+/* Custom styles for Canvas */
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+}


### PR DESCRIPTION
Revise the project structure to include loading and rendering GLB 3D models in React Three Fiber using Next.js.

* **Add `app/components/Model.tsx`**
  - Import `useLoader` from `@react-three/fiber` and `GLTFLoader` from `three/examples/jsm/loaders/GLTFLoader`
  - Use `useLoader` to load the GLB model from `/models/scene.glb`
  - Return a `primitive` object with `gltf.scene`

* **Add `app/page.tsx`**
  - Import `Canvas` from `@react-three/fiber`
  - Import `Model` from `./components/Model`
  - Create a `Canvas` component and render `Model` inside it

* **Add `styles/canvas.css`**
  - Add custom styles for the `Canvas` component

* **Add `next.config.js`**
  - Add Next.js configuration file with necessary settings

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/next-r3f-glb/pull/2?shareId=2f9bbd32-b8f0-4d6d-958f-aa94d96db179).